### PR TITLE
Use less restrictive behavior for date selections for both calendars

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -572,7 +572,7 @@
                     this.rightCalendar.month = this.startDate.clone().date(2).add(1, 'month');
                 }
             }
-            if (this.maxDate && this.linkedCalendars && !this.singleDatePicker && this.rightCalendar.month > this.maxDate) {
+            if (this.maxDate && !this.singleDatePicker && this.rightCalendar.month > this.maxDate) {
               this.rightCalendar.month = this.maxDate.clone().date(2);
               this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
             }
@@ -688,7 +688,7 @@
             // Display the calendar
             //
 
-            var minDate = side == 'left' ? this.minDate : this.startDate;
+            var minDate = this.minDate;
             var maxDate = this.maxDate;
             var selected = side == 'left' ? this.startDate : this.endDate;
             var arrow = {left: 'svg-caret-left', right: 'svg-caret-right'};
@@ -719,15 +719,9 @@
 
                 var monthHtml = '<select class="monthselect">';
                 for (var m = 0; m < 12; m++) {
-                    if ((!inMinYear || m >= minDate.month()) && (!inMaxYear || m <= maxDate.month())) {
-                        monthHtml += "<option value='" + m + "'" +
-                            (m === currentMonth ? " selected='selected'" : "") +
-                            ">" + this.locale.monthNames[m] + "</option>";
-                    } else {
-                        monthHtml += "<option value='" + m + "'" +
-                            (m === currentMonth ? " selected='selected'" : "") +
-                            " disabled='disabled'>" + this.locale.monthNames[m] + "</option>";
-                    }
+                    monthHtml += "<option value='" + m + "'" +
+                        (m === currentMonth ? " selected='selected'" : "") +
+                        ">" + this.locale.monthNames[m] + "</option>";
                 }
                 monthHtml += "</select>";
 
@@ -1438,27 +1432,6 @@
             var month = parseInt(cal.find('.monthselect').val(), 10);
             var year = cal.find('.yearselect').val();
 
-            if (!isLeft) {
-                if (year < this.startDate.year() || (year == this.startDate.year() && month < this.startDate.month())) {
-                    month = this.startDate.month();
-                    year = this.startDate.year();
-                }
-            }
-
-            if (this.minDate) {
-                if (year < this.minDate.year() || (year == this.minDate.year() && month < this.minDate.month())) {
-                    month = this.minDate.month();
-                    year = this.minDate.year();
-                }
-            }
-
-            if (this.maxDate) {
-                if (year > this.maxDate.year() || (year == this.maxDate.year() && month > this.maxDate.month())) {
-                    month = this.maxDate.month();
-                    year = this.maxDate.year();
-                }
-            }
-
             if (isLeft) {
                 this.leftCalendar.month.month(month).year(year);
                 if (this.linkedCalendars)
@@ -1645,3 +1618,4 @@
     return DateRangePicker;
 
 }));
+


### PR DESCRIPTION
Slack link: https://heap.slack.com/archives/CF04C0L3C/p1574808979005900

For context, this repo is a fork of the library we use for date pickers in the webapp. We've made a few changes to the fork in the past, and I'm making a few here to address issues I've identified in https://heapinc.atlassian.net/wiki/spaces/ENG/pages/40239177/Date+Range+Picker+-+Problems+Solutions+and+User+Testing

Specifically, this allows for:
- arbitrary selection of month/year in the (right) calendar, regardless of what's chosen in the (left) calendar
- selecting a month when the month for that year hasn't happened yet (e.g. if it's currently November 2019, this allows you to "navigate to"/select December 2019, but still correctly doesn't let you pick any dates in December. This lets you pick the month, then the year, which wasn't possible and caused people to run into issues during user testing.

e.g. they wanted to pick December 31st, 2018, but if the currently chosen year was 2019, we didn't let you pick December (since December 2019 hasn't happened yet), then 2018; you had to pick the year and then the month, which in practice wasn't how people thought about the selection. We should allow people to pick either the month or year first.

I can also demo how this works in the app for you if you'd like.

After this PR is merged, I'll update https://github.com/heap/heap/pull/25777 to use the new git hash in the heap repo's package.json and lockfile.